### PR TITLE
Fix MasteryTracker

### DIFF
--- a/Professions/Framework/Patchers/Prestige/MasteryTrackerMenuReceiveLeftClickPatcher.cs
+++ b/Professions/Framework/Patchers/Prestige/MasteryTrackerMenuReceiveLeftClickPatcher.cs
@@ -33,6 +33,11 @@ internal sealed class MasteryTrackerMenuReceiveLeftClickPatcher : HarmonyPatcher
         int y,
         int ___which)
     {
+        if (___which == -1)
+        {
+            return true;
+        }
+
         if (State.WarningBox is not null)
         {
             return false; // don't run original logic


### PR DESCRIPTION
It can cause problems when is opened in the pedestal (which == -1). It has no button by itself, but other mods can add one.