### PR TITLE
Fix stackoverflow by wrong use of Prefix instead of Postfix patching

### DIFF
--- a/Professions/Framework/Patchers/Farming/FarmAnimalGetSellPricePatcher.cs
+++ b/Professions/Framework/Patchers/Farming/FarmAnimalGetSellPricePatcher.cs
@@ -25,22 +25,21 @@ internal sealed class FarmAnimalGetSellPricePatcher : HarmonyPatcher
     /// <summary>Patch to adjust Breeder animal sell price.</summary>
     [HarmonyPostfix]
     [UsedImplicitly]
-    private static bool FarmAnimalGetSellPricePostfix(FarmAnimal __instance, ref int __result)
+    private static void FarmAnimalGetSellPricePostfix(FarmAnimal __instance, ref int __result)
     {
         if (!__instance.DoesOwnerHaveProfessionOrLax(Profession.Breeder))
         {
-            return true; // run original logic
+            return; // do not change sell price
         }
 
         try
         {
-            __result = (int)(__result * __instance.GetBreederAdjustedPrice());
-            return false; // don't run original logic
+            __result = (int)(__result * __instance.GetBreederAdjustedPrice()); 
         }
         catch (Exception ex)
         {
             Log.E($"Failed in {MethodBase.GetCurrentMethod()?.Name}:\n{ex}");
-            return true; // default to original logic
+            return; // default to original logic
         }
     }
 

--- a/Professions/Framework/Patchers/Farming/FarmAnimalGetSellPricePatcher.cs
+++ b/Professions/Framework/Patchers/Farming/FarmAnimalGetSellPricePatcher.cs
@@ -23,9 +23,9 @@ internal sealed class FarmAnimalGetSellPricePatcher : HarmonyPatcher
     #region harmony patches
 
     /// <summary>Patch to adjust Breeder animal sell price.</summary>
-    [HarmonyPrefix]
+    [HarmonyPostfix]
     [UsedImplicitly]
-    private static bool FarmAnimalGetSellPricePrefix(FarmAnimal __instance, ref int __result)
+    private static bool FarmAnimalGetSellPricePostfix(FarmAnimal __instance, ref int __result)
     {
         if (!__instance.DoesOwnerHaveProfessionOrLax(Profession.Breeder))
         {
@@ -34,7 +34,7 @@ internal sealed class FarmAnimalGetSellPricePatcher : HarmonyPatcher
 
         try
         {
-            __result = (int)(__instance.getSellPrice() * __instance.GetBreederAdjustedPrice());
+            __result = (int)(__result * __instance.GetBreederAdjustedPrice());
             return false; // don't run original logic
         }
         catch (Exception ex)


### PR DESCRIPTION
Fixes #36

It's pretty self-explanatory, but:

By using Prefix, when the game calls the `FarmAnimal.getSellPrice` method, Harmony calls your patch first. However, your patch then calls the `FarmAnimal.getSellPrice` method, Harmony calls your patch again first, then your patch calls `FarmAnimal.getSellPrice` again... and so on, leading to the StackOverflow error.

By correctly using postfix patching, this is resolved.